### PR TITLE
Fix duplicate const in IP usage check

### DIFF
--- a/proxy/checker/ip.go
+++ b/proxy/checker/ip.go
@@ -1,0 +1,77 @@
+package checker
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	ipcheck "github.com/bestruirui/bestsub/proxy/checker/ip"
+	"github.com/bestruirui/bestsub/utils/log"
+)
+
+// getPublicIP retrieves the outbound IP address using the proxy client.
+func (c *Checker) getPublicIP() (string, error) {
+	ctx, cancel := context.WithTimeout(c.Proxy.Ctx, 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://api64.ipify.org?format=text", nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.Proxy.Client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("ip service returned %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(body)), nil
+}
+
+// IPTest gathers IP related information using various online services.
+func (c *Checker) IPTest() {
+	ipAddr, err := c.getPublicIP()
+	if err != nil {
+		log.Debug("failed to obtain public IP: %v", err)
+		return
+	}
+
+	if ipAddr == "" {
+		return
+	}
+
+	if usage, err := ipcheck.GetIPUsageInfo(ipAddr); err == nil {
+		c.Proxy.Info.IP.IPUsage = usage
+	} else {
+		log.Debug("get IP usage info failed: %v", err)
+	}
+
+	if risk, err := ipcheck.GetIPRiskInfo(ipAddr); err == nil {
+		c.Proxy.Info.IP.IPRisk = risk
+	} else {
+		log.Debug("get IP risk info failed: %v", err)
+	}
+
+	if factors, err := ipcheck.GetIPRiskFactorInfo(ipAddr); err == nil {
+		c.Proxy.Info.IP.IPRiskFactor = factors
+	} else {
+		log.Debug("get IP risk factor info failed: %v", err)
+	}
+
+	if banned, err := ipcheck.GetIPBannedInfo(ipAddr); err == nil {
+		c.Proxy.Info.IP.IPBanned = banned
+	} else {
+		log.Debug("get IP banned info failed: %v", err)
+	}
+}

--- a/proxy/checker/ip/ip2location_checker.go
+++ b/proxy/checker/ip/ip2location_checker.go
@@ -3,6 +3,8 @@ package ip
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/bestruirui/bestsub/proxy/info"
 )
 
 // JSON Structs for IP2Location
@@ -51,4 +53,4 @@ func FetchIP2LocationRiskFactors(ipAddr string, client *http.Client) (factors in
 	// factors.Spam remains false
 
 	return factors, nil
-} 
+}

--- a/proxy/checker/ip/ipapi_checker.go
+++ b/proxy/checker/ip/ipapi_checker.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/bestruirui/bestsub/proxy/info"
 )
 
 // JSON Structs for IPApi
@@ -22,12 +24,12 @@ type ipApiResponse struct {
 	ASN     ipApiASN     `json:"asn"`
 	Company ipApiCompany `json:"company"`
 	// For Risk Factors
-	Location    ipApiLocation `json:"location"`
-	IsProxy     bool          `json:"is_proxy"`
-	IsTor       bool          `json:"is_tor"`
-	IsVPN       bool          `json:"is_vpn"`
-	IsDatacenter bool         `json:"is_datacenter"`
-	IsAbuser    bool          `json:"is_abuser"`
+	Location     ipApiLocation `json:"location"`
+	IsProxy      bool          `json:"is_proxy"`
+	IsTor        bool          `json:"is_tor"`
+	IsVPN        bool          `json:"is_vpn"`
+	IsDatacenter bool          `json:"is_datacenter"`
+	IsAbuser     bool          `json:"is_abuser"`
 }
 
 // FetchIPApiUsageData fetches usage types from api.ipapi.is
@@ -51,7 +53,7 @@ func FetchIPAPIRiskScore(ipAddr string, client *http.Client) (riskScore info.IPR
 	if err != nil {
 		return info.IPRiskScoreLow, fmt.Errorf("FetchIPAPIRiskScore failed for IP %s: %w", ipAddr, err)
 	}
-	
+
 	// Extract the text part of the score, e.g., "Very Low" from "0 (Very Low)"
 	scoreText := respData.Company.AbuserScore
 	if strings.Contains(scoreText, "(") {
@@ -82,4 +84,4 @@ func FetchIPAPIRiskFactors(ipAddr string, client *http.Client) (factors info.IPR
 	// factors.Spam remains false as per plan
 
 	return factors, nil
-} 
+}

--- a/proxy/checker/ip/ipinfo_checker.go
+++ b/proxy/checker/ip/ipinfo_checker.go
@@ -3,6 +3,8 @@ package ip
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/bestruirui/bestsub/proxy/info"
 )
 
 // JSON Structs for IPInfo
@@ -33,7 +35,7 @@ func FetchIPInfoUsageData(ipAddr string, client *http.Client) (asnType string, c
 	var respData ipInfoResponse
 	url := fmt.Sprintf("https://ipinfo.io/widget/demo/%s", ipAddr)
 
-	err = genericFetchJSON(url, client, &respData) 
+	err = genericFetchJSON(url, client, &respData)
 	if err != nil {
 		return "", "", fmt.Errorf("FetchIPInfoUsageData failed for IP %s: %w", ipAddr, err)
 	}
@@ -42,7 +44,7 @@ func FetchIPInfoUsageData(ipAddr string, client *http.Client) (asnType string, c
 
 // FetchIPInfoRiskFactors fetches risk factors from ipinfo.io
 func FetchIPInfoRiskFactors(ipAddr string, client *http.Client) (factors info.IPRiskFactor, err error) {
-	var respData ipInfoResponse 
+	var respData ipInfoResponse
 	url := fmt.Sprintf("https://ipinfo.io/widget/demo/%s", ipAddr)
 
 	err = genericFetchJSON(url, client, &respData)
@@ -58,4 +60,4 @@ func FetchIPInfoRiskFactors(ipAddr string, client *http.Client) (factors info.IP
 	// Abuse is not directly provided by IPInfo in this structure
 
 	return factors, nil
-} 
+}

--- a/proxy/checker/ip/ipregistry_checker.go
+++ b/proxy/checker/ip/ipregistry_checker.go
@@ -3,6 +3,8 @@ package ip
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/bestruirui/bestsub/proxy/info"
 )
 
 // JSON Structs for IPRegistry
@@ -63,4 +65,4 @@ func FetchIPRegistryRiskFactors(ipAddr string, client *http.Client) (factors inf
 	factors.Abuse = respData.Security.IsAbuser
 
 	return factors, nil
-} 
+}

--- a/proxy/checker/ip/usage.go
+++ b/proxy/checker/ip/usage.go
@@ -8,11 +8,6 @@ import (
 	"github.com/bestruirui/bestsub/proxy/info"
 )
 
-const (
-	defaultTimeout = 10 * time.Second
-	userAgent      = "BestSub IP Checker/1.0" // Example User-Agent
-)
-
 // toIPUsageType maps API type strings to info.IPUsageType
 func toIPUsageType(apiTypeRaw string) info.IPUsageType {
 	if apiTypeRaw == "" {
@@ -45,8 +40,8 @@ func toIPUsageType(apiTypeRaw string) info.IPUsageType {
 // GetIPUsageInfo fetches IP usage information from various APIs.
 func GetIPUsageInfo(ipAddr string) (info.IPUsageInfo, error) {
 	// client is initialized using defaultTimeout from utils.go (same package, so no import needed for defaultTimeout)
-	client := &http.Client{Timeout: defaultTimeout} 
-	usageInfo := info.IPUsageInfo{} 
+	client := &http.Client{Timeout: defaultTimeout}
+	usageInfo := info.IPUsageInfo{}
 
 	var collectedErrors []string
 
@@ -76,7 +71,7 @@ func GetIPUsageInfo(ipAddr string) (info.IPUsageInfo, error) {
 		usageInfo.IPApi = toIPUsageType(ipApiAsnType)
 		usageInfo.IPApiHost = toIPUsageType(ipApiCompType)
 	}
-	
+
 	// Fetch from AbuseIPDB
 	abuseIPDBUsageType, err := FetchAbuseIPDBUsageData(ipAddr, client)
 	if err != nil {
@@ -103,4 +98,4 @@ func GetIPUsageInfo(ipAddr string) (info.IPUsageInfo, error) {
 	}
 
 	return usageInfo, nil
-} 
+}

--- a/proxy/checker/ip/utils.go
+++ b/proxy/checker/ip/utils.go
@@ -3,11 +3,13 @@ package ip
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
-	"net"
-	"regexp"
+
+	"github.com/bestruirui/bestsub/proxy/info"
 )
 
 const (
@@ -75,7 +77,7 @@ func mapAbuseIPDBScoreToEnum(rawScore int) info.IPRiskScore {
 		return info.IPRiskScoreVeryHigh
 	}
 	if rawScore >= 25 { // Between 25 and 74
-		return info.IPRiskScoreHigh 
+		return info.IPRiskScoreHigh
 	}
 	return info.IPRiskScoreLow // 0-24
 }
@@ -112,29 +114,29 @@ func ValidateIP(ipStr string) string {
 	cleanIP := strings.TrimSpace(ipStr)
 	cleanIP = strings.TrimSuffix(cleanIP, "\n")
 	cleanIP = strings.TrimSuffix(cleanIP, "\r")
-	
+
 	// 使用正则表达式提取IP地址
 	ipv4Regex := regexp.MustCompile(`(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})`)
 	ipv6Regex := regexp.MustCompile(`([0-9a-fA-F:]+::[0-9a-fA-F:]*|[0-9a-fA-F:]*::[0-9a-fA-F:]+|[0-9a-fA-F:]+:[0-9a-fA-F:]+:[0-9a-fA-F:]+:[0-9a-fA-F:]+:[0-9a-fA-F:]+:[0-9a-fA-F:]+:[0-9a-fA-F:]+:[0-9a-fA-F:]+)`)
-	
+
 	// 先尝试IPv4
 	if match := ipv4Regex.FindString(cleanIP); match != "" {
 		if net.ParseIP(match) != nil {
 			return match
 		}
 	}
-	
+
 	// 再尝试IPv6
 	if match := ipv6Regex.FindString(cleanIP); match != "" {
 		if net.ParseIP(match) != nil {
 			return match
 		}
 	}
-	
+
 	// 直接验证清理后的字符串
 	if net.ParseIP(cleanIP) != nil {
 		return cleanIP
 	}
-	
+
 	return ""
-} 
+}


### PR DESCRIPTION
## Summary
- remove duplicate `defaultTimeout` and `userAgent` constants from `usage.go`

## Testing
- `go vet ./...` *(fails: proxyconnect tcp - no route to host)*
- `go test ./...` *(fails: proxyconnect tcp - no route to host)*