### PR TITLE
Fix imports and remove duplicated IP code

### DIFF
--- a/proxy/checker/ip.go
+++ b/proxy/checker/ip.go
@@ -1,0 +1,77 @@
+package checker
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	ipcheck "github.com/bestruirui/bestsub/proxy/checker/ip"
+	"github.com/bestruirui/bestsub/utils/log"
+)
+
+// getPublicIP retrieves the outbound IP address using the proxy client.
+func (c *Checker) getPublicIP() (string, error) {
+	ctx, cancel := context.WithTimeout(c.Proxy.Ctx, 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://api64.ipify.org?format=text", nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.Proxy.Client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("ip service returned %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(body)), nil
+}
+
+// IPTest gathers IP related information using various online services.
+func (c *Checker) IPTest() {
+	ipAddr, err := c.getPublicIP()
+	if err != nil {
+		log.Debug("failed to obtain public IP: %v", err)
+		return
+	}
+
+	if ipAddr == "" {
+		return
+	}
+
+	if usage, err := ipcheck.GetIPUsageInfo(ipAddr); err == nil {
+		c.Proxy.Info.IP.IPUsage = usage
+	} else {
+		log.Debug("get IP usage info failed: %v", err)
+	}
+
+	if risk, err := ipcheck.GetIPRiskInfo(ipAddr); err == nil {
+		c.Proxy.Info.IP.IPRisk = risk
+	} else {
+		log.Debug("get IP risk info failed: %v", err)
+	}
+
+	if factors, err := ipcheck.GetIPRiskFactorInfo(ipAddr); err == nil {
+		c.Proxy.Info.IP.IPRiskFactor = factors
+	} else {
+		log.Debug("get IP risk factor info failed: %v", err)
+	}
+
+	if banned, err := ipcheck.GetIPBannedInfo(ipAddr); err == nil {
+		c.Proxy.Info.IP.IPBanned = banned
+	} else {
+		log.Debug("get IP banned info failed: %v", err)
+	}
+}

--- a/proxy/checker/ip/aggregator.go
+++ b/proxy/checker/ip/aggregator.go
@@ -12,18 +12,19 @@ import (
 func GetIPRiskInfo(ipAddr string) (info.IPRiskInfo, error) {
 	client := &http.Client{Timeout: defaultTimeout}
 	riskInfo := info.IPRiskInfo{}
-	
+
 	var wg sync.WaitGroup
 	var mutex sync.Mutex
 	var collectedErrors []string
-	
+
 	// 并发获取各个服务的风险评分
 	wg.Add(5)
-	
+
 	// Scamalytics 风险评分
 	go func() {
 		defer wg.Done()
-		if score, err := FetchScamalyticsRiskScore(ipAddr, client); err != nil {
+		score, _, _, _, _, _, err := FetchScamalyticsRiskData(ipAddr, client)
+		if err != nil {
 			mutex.Lock()
 			collectedErrors = append(collectedErrors, fmt.Sprintf("Scamalytics error: %v", err))
 			mutex.Unlock()
@@ -33,7 +34,7 @@ func GetIPRiskInfo(ipAddr string) (info.IPRiskInfo, error) {
 			mutex.Unlock()
 		}
 	}()
-	
+
 	// IPAPI 风险评分
 	go func() {
 		defer wg.Done()
@@ -47,7 +48,7 @@ func GetIPRiskInfo(ipAddr string) (info.IPRiskInfo, error) {
 			mutex.Unlock()
 		}
 	}()
-	
+
 	// AbuseIPDB 风险评分
 	go func() {
 		defer wg.Done()
@@ -61,7 +62,7 @@ func GetIPRiskInfo(ipAddr string) (info.IPRiskInfo, error) {
 			mutex.Unlock()
 		}
 	}()
-	
+
 	// IPQS 风险评分
 	go func() {
 		defer wg.Done()
@@ -75,7 +76,7 @@ func GetIPRiskInfo(ipAddr string) (info.IPRiskInfo, error) {
 			mutex.Unlock()
 		}
 	}()
-	
+
 	// DBIP 风险评分
 	go func() {
 		defer wg.Done()
@@ -89,9 +90,9 @@ func GetIPRiskInfo(ipAddr string) (info.IPRiskInfo, error) {
 			mutex.Unlock()
 		}
 	}()
-	
+
 	wg.Wait()
-	
+
 	// 处理错误
 	if len(collectedErrors) > 0 {
 		if len(collectedErrors) == 5 {
@@ -99,64 +100,6 @@ func GetIPRiskInfo(ipAddr string) (info.IPRiskInfo, error) {
 		}
 		return riskInfo, fmt.Errorf("部分IP风险评分API调用失败")
 	}
-	
+
 	return riskInfo, nil
 }
-
-// FetchScamalyticsRiskScore 获取Scamalytics风险评分
-func FetchScamalyticsRiskScore(ipAddr string, client *http.Client) (info.IPRiskScore, error) {
-	// 这里应该调用Scamalytics API获取风险评分
-	// 由于现有代码中可能已有实现，暂时返回默认值
-	return info.IPRiskScoreLow, nil
-}
-
-// FetchIPAPIRiskScore 获取IPAPI风险评分
-func FetchIPAPIRiskScore(ipAddr string, client *http.Client) (info.IPRiskScore, error) {
-	// 这里应该调用IPAPI风险评分API
-	return info.IPRiskScoreLow, nil
-}
-
-// FetchAbuseIPDBRiskScore 获取AbuseIPDB风险评分
-func FetchAbuseIPDBRiskScore(ipAddr string, client *http.Client) (info.IPRiskScore, error) {
-	// 使用现有的AbuseIPDB检测器
-	type abuseResponse struct {
-		AbuseConfidencePercentage int `json:"abuseConfidencePercentage"`
-	}
-	
-	var resp abuseResponse
-	url := fmt.Sprintf("https://api.abuseipdb.com/api/v2/check?ipAddress=%s", ipAddr)
-	
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return info.IPRiskScoreLow, fmt.Errorf("failed to create request: %w", err)
-	}
-	
-	// 注意：实际使用时需要API密钥
-	req.Header.Set("Key", "YOUR_API_KEY")
-	req.Header.Set("Accept", "application/json")
-	
-	httpResp, err := client.Do(req)
-	if err != nil {
-		return info.IPRiskScoreLow, fmt.Errorf("failed to execute request: %w", err)
-	}
-	defer httpResp.Body.Close()
-	
-	if httpResp.StatusCode != http.StatusOK {
-		return info.IPRiskScoreLow, fmt.Errorf("bad status code: %d", httpResp.StatusCode)
-	}
-	
-	// 解析响应并转换为风险评分
-	return mapAbuseIPDBScoreToEnum(resp.AbuseConfidencePercentage), nil
-}
-
-// FetchIPQSRiskScore 获取IPQS风险评分
-func FetchIPQSRiskScore(ipAddr string, client *http.Client) (info.IPRiskScore, error) {
-	// 这里应该调用IPQS API获取风险评分
-	return info.IPRiskScoreLow, nil
-}
-
-// FetchDBIPRiskScore 获取DBIP风险评分
-func FetchDBIPRiskScore(ipAddr string, client *http.Client) (info.IPRiskScore, error) {
-	// 这里应该调用DBIP API获取风险评分
-	return info.IPRiskScoreLow, nil
-} 

--- a/proxy/checker/ip/banned_checker.go
+++ b/proxy/checker/ip/banned_checker.go
@@ -1,11 +1,7 @@
 package ip
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
-	"strings"
-	"time"
 
 	"github.com/bestruirui/bestsub/proxy/info"
 )
@@ -21,10 +17,10 @@ type BannedCheckResult struct {
 func GetIPBannedInfo(ipAddr string) (info.IPBannedInfo, error) {
 	client := &http.Client{Timeout: defaultTimeout}
 	bannedInfo := info.IPBannedInfo{}
-	
+
 	// 执行多个平台的封禁检测
 	results := make(chan BannedCheckResult, 6)
-	
+
 	// 启动并发检测
 	go checkGoogleBanned(ipAddr, client, results)
 	go checkNetflixBanned(ipAddr, client, results)
@@ -32,7 +28,7 @@ func GetIPBannedInfo(ipAddr string) (info.IPBannedInfo, error) {
 	go checkCloudFlareBanned(ipAddr, client, results)
 	go checkSpotifyBanned(ipAddr, client, results)
 	go checkOpenAIBanned(ipAddr, client, results)
-	
+
 	// 收集结果
 	for i := 0; i < 6; i++ {
 		result := <-results
@@ -45,14 +41,14 @@ func GetIPBannedInfo(ipAddr string) (info.IPBannedInfo, error) {
 			bannedInfo.Banned++
 		}
 	}
-	
+
 	return bannedInfo, nil
 }
 
 // checkGoogleBanned 检测Google平台封禁状态
 func checkGoogleBanned(ipAddr string, client *http.Client, results chan<- BannedCheckResult) {
 	status := 0 // 默认正常
-	
+
 	// 检测Google访问状态
 	req, err := http.NewRequest("GET", "https://www.google.com/generate_204", nil)
 	if err != nil {
@@ -60,7 +56,7 @@ func checkGoogleBanned(ipAddr string, client *http.Client, results chan<- Banned
 		return
 	}
 	req.Header.Set("User-Agent", userAgent)
-	
+
 	resp, err := client.Do(req)
 	if err != nil {
 		status = 2 // 无法访问，视为封禁
@@ -72,21 +68,21 @@ func checkGoogleBanned(ipAddr string, client *http.Client, results chan<- Banned
 			status = 2 // 非正常响应，视为封禁
 		}
 	}
-	
+
 	results <- BannedCheckResult{Platform: "Google", Status: status, Error: err}
 }
 
 // checkNetflixBanned 检测Netflix平台封禁状态
 func checkNetflixBanned(ipAddr string, client *http.Client, results chan<- BannedCheckResult) {
 	status := 0
-	
+
 	req, err := http.NewRequest("GET", "https://www.netflix.com/title/70143836", nil)
 	if err != nil {
 		results <- BannedCheckResult{Platform: "Netflix", Status: status, Error: err}
 		return
 	}
 	req.Header.Set("User-Agent", userAgent)
-	
+
 	resp, err := client.Do(req)
 	if err != nil {
 		status = 2
@@ -98,21 +94,21 @@ func checkNetflixBanned(ipAddr string, client *http.Client, results chan<- Banne
 			status = 1 // 其他错误状态
 		}
 	}
-	
+
 	results <- BannedCheckResult{Platform: "Netflix", Status: status, Error: err}
 }
 
 // checkAmazonBanned 检测Amazon平台封禁状态
 func checkAmazonBanned(ipAddr string, client *http.Client, results chan<- BannedCheckResult) {
 	status := 0
-	
+
 	req, err := http.NewRequest("GET", "https://www.amazon.com/dp/B07HXRHDVR", nil)
 	if err != nil {
 		results <- BannedCheckResult{Platform: "Amazon", Status: status, Error: err}
 		return
 	}
 	req.Header.Set("User-Agent", userAgent)
-	
+
 	resp, err := client.Do(req)
 	if err != nil {
 		status = 2
@@ -124,21 +120,21 @@ func checkAmazonBanned(ipAddr string, client *http.Client, results chan<- Banned
 			status = 1
 		}
 	}
-	
+
 	results <- BannedCheckResult{Platform: "Amazon", Status: status, Error: err}
 }
 
 // checkCloudFlareBanned 检测CloudFlare平台封禁状态
 func checkCloudFlareBanned(ipAddr string, client *http.Client, results chan<- BannedCheckResult) {
 	status := 0
-	
+
 	req, err := http.NewRequest("GET", "https://www.cloudflare.com/cdn-cgi/trace", nil)
 	if err != nil {
 		results <- BannedCheckResult{Platform: "CloudFlare", Status: status, Error: err}
 		return
 	}
 	req.Header.Set("User-Agent", userAgent)
-	
+
 	resp, err := client.Do(req)
 	if err != nil {
 		status = 2
@@ -150,21 +146,21 @@ func checkCloudFlareBanned(ipAddr string, client *http.Client, results chan<- Ba
 			status = 1 // 限速
 		}
 	}
-	
+
 	results <- BannedCheckResult{Platform: "CloudFlare", Status: status, Error: err}
 }
 
 // checkSpotifyBanned 检测Spotify平台封禁状态
 func checkSpotifyBanned(ipAddr string, client *http.Client, results chan<- BannedCheckResult) {
 	status := 0
-	
+
 	req, err := http.NewRequest("GET", "https://open.spotify.com/", nil)
 	if err != nil {
 		results <- BannedCheckResult{Platform: "Spotify", Status: status, Error: err}
 		return
 	}
 	req.Header.Set("User-Agent", userAgent)
-	
+
 	resp, err := client.Do(req)
 	if err != nil {
 		status = 2
@@ -176,21 +172,21 @@ func checkSpotifyBanned(ipAddr string, client *http.Client, results chan<- Banne
 			status = 1
 		}
 	}
-	
+
 	results <- BannedCheckResult{Platform: "Spotify", Status: status, Error: err}
 }
 
 // checkOpenAIBanned 检测OpenAI平台封禁状态
 func checkOpenAIBanned(ipAddr string, client *http.Client, results chan<- BannedCheckResult) {
 	status := 0
-	
+
 	req, err := http.NewRequest("GET", "https://chat.openai.com/", nil)
 	if err != nil {
 		results <- BannedCheckResult{Platform: "OpenAI", Status: status, Error: err}
 		return
 	}
 	req.Header.Set("User-Agent", userAgent)
-	
+
 	resp, err := client.Do(req)
 	if err != nil {
 		status = 2
@@ -202,6 +198,6 @@ func checkOpenAIBanned(ipAddr string, client *http.Client, results chan<- Banned
 			status = 1
 		}
 	}
-	
+
 	results <- BannedCheckResult{Platform: "OpenAI", Status: status, Error: err}
-} 
+}

--- a/proxy/checker/ip/ip2location_checker.go
+++ b/proxy/checker/ip/ip2location_checker.go
@@ -3,6 +3,8 @@ package ip
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/bestruirui/bestsub/proxy/info"
 )
 
 // JSON Structs for IP2Location
@@ -51,4 +53,4 @@ func FetchIP2LocationRiskFactors(ipAddr string, client *http.Client) (factors in
 	// factors.Spam remains false
 
 	return factors, nil
-} 
+}

--- a/proxy/checker/ip/ipapi_checker.go
+++ b/proxy/checker/ip/ipapi_checker.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/bestruirui/bestsub/proxy/info"
 )
 
 // JSON Structs for IPApi
@@ -22,12 +24,12 @@ type ipApiResponse struct {
 	ASN     ipApiASN     `json:"asn"`
 	Company ipApiCompany `json:"company"`
 	// For Risk Factors
-	Location    ipApiLocation `json:"location"`
-	IsProxy     bool          `json:"is_proxy"`
-	IsTor       bool          `json:"is_tor"`
-	IsVPN       bool          `json:"is_vpn"`
-	IsDatacenter bool         `json:"is_datacenter"`
-	IsAbuser    bool          `json:"is_abuser"`
+	Location     ipApiLocation `json:"location"`
+	IsProxy      bool          `json:"is_proxy"`
+	IsTor        bool          `json:"is_tor"`
+	IsVPN        bool          `json:"is_vpn"`
+	IsDatacenter bool          `json:"is_datacenter"`
+	IsAbuser     bool          `json:"is_abuser"`
 }
 
 // FetchIPApiUsageData fetches usage types from api.ipapi.is
@@ -51,7 +53,7 @@ func FetchIPAPIRiskScore(ipAddr string, client *http.Client) (riskScore info.IPR
 	if err != nil {
 		return info.IPRiskScoreLow, fmt.Errorf("FetchIPAPIRiskScore failed for IP %s: %w", ipAddr, err)
 	}
-	
+
 	// Extract the text part of the score, e.g., "Very Low" from "0 (Very Low)"
 	scoreText := respData.Company.AbuserScore
 	if strings.Contains(scoreText, "(") {
@@ -82,4 +84,4 @@ func FetchIPAPIRiskFactors(ipAddr string, client *http.Client) (factors info.IPR
 	// factors.Spam remains false as per plan
 
 	return factors, nil
-} 
+}

--- a/proxy/checker/ip/ipinfo_checker.go
+++ b/proxy/checker/ip/ipinfo_checker.go
@@ -3,6 +3,8 @@ package ip
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/bestruirui/bestsub/proxy/info"
 )
 
 // JSON Structs for IPInfo
@@ -33,7 +35,7 @@ func FetchIPInfoUsageData(ipAddr string, client *http.Client) (asnType string, c
 	var respData ipInfoResponse
 	url := fmt.Sprintf("https://ipinfo.io/widget/demo/%s", ipAddr)
 
-	err = genericFetchJSON(url, client, &respData) 
+	err = genericFetchJSON(url, client, &respData)
 	if err != nil {
 		return "", "", fmt.Errorf("FetchIPInfoUsageData failed for IP %s: %w", ipAddr, err)
 	}
@@ -42,7 +44,7 @@ func FetchIPInfoUsageData(ipAddr string, client *http.Client) (asnType string, c
 
 // FetchIPInfoRiskFactors fetches risk factors from ipinfo.io
 func FetchIPInfoRiskFactors(ipAddr string, client *http.Client) (factors info.IPRiskFactor, err error) {
-	var respData ipInfoResponse 
+	var respData ipInfoResponse
 	url := fmt.Sprintf("https://ipinfo.io/widget/demo/%s", ipAddr)
 
 	err = genericFetchJSON(url, client, &respData)
@@ -58,4 +60,4 @@ func FetchIPInfoRiskFactors(ipAddr string, client *http.Client) (factors info.IP
 	// Abuse is not directly provided by IPInfo in this structure
 
 	return factors, nil
-} 
+}

--- a/proxy/checker/ip/ipregistry_checker.go
+++ b/proxy/checker/ip/ipregistry_checker.go
@@ -3,6 +3,8 @@ package ip
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/bestruirui/bestsub/proxy/info"
 )
 
 // JSON Structs for IPRegistry
@@ -63,4 +65,4 @@ func FetchIPRegistryRiskFactors(ipAddr string, client *http.Client) (factors inf
 	factors.Abuse = respData.Security.IsAbuser
 
 	return factors, nil
-} 
+}

--- a/proxy/checker/ip/usage.go
+++ b/proxy/checker/ip/usage.go
@@ -8,11 +8,6 @@ import (
 	"github.com/bestruirui/bestsub/proxy/info"
 )
 
-const (
-	defaultTimeout = 10 * time.Second
-	userAgent      = "BestSub IP Checker/1.0" // Example User-Agent
-)
-
 // toIPUsageType maps API type strings to info.IPUsageType
 func toIPUsageType(apiTypeRaw string) info.IPUsageType {
 	if apiTypeRaw == "" {
@@ -45,8 +40,8 @@ func toIPUsageType(apiTypeRaw string) info.IPUsageType {
 // GetIPUsageInfo fetches IP usage information from various APIs.
 func GetIPUsageInfo(ipAddr string) (info.IPUsageInfo, error) {
 	// client is initialized using defaultTimeout from utils.go (same package, so no import needed for defaultTimeout)
-	client := &http.Client{Timeout: defaultTimeout} 
-	usageInfo := info.IPUsageInfo{} 
+	client := &http.Client{Timeout: defaultTimeout}
+	usageInfo := info.IPUsageInfo{}
 
 	var collectedErrors []string
 
@@ -76,7 +71,7 @@ func GetIPUsageInfo(ipAddr string) (info.IPUsageInfo, error) {
 		usageInfo.IPApi = toIPUsageType(ipApiAsnType)
 		usageInfo.IPApiHost = toIPUsageType(ipApiCompType)
 	}
-	
+
 	// Fetch from AbuseIPDB
 	abuseIPDBUsageType, err := FetchAbuseIPDBUsageData(ipAddr, client)
 	if err != nil {
@@ -103,4 +98,4 @@ func GetIPUsageInfo(ipAddr string) (info.IPUsageInfo, error) {
 	}
 
 	return usageInfo, nil
-} 
+}

--- a/proxy/checker/ip/utils.go
+++ b/proxy/checker/ip/utils.go
@@ -3,11 +3,13 @@ package ip
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
-	"net"
-	"regexp"
+
+	"github.com/bestruirui/bestsub/proxy/info"
 )
 
 const (
@@ -75,7 +77,7 @@ func mapAbuseIPDBScoreToEnum(rawScore int) info.IPRiskScore {
 		return info.IPRiskScoreVeryHigh
 	}
 	if rawScore >= 25 { // Between 25 and 74
-		return info.IPRiskScoreHigh 
+		return info.IPRiskScoreHigh
 	}
 	return info.IPRiskScoreLow // 0-24
 }
@@ -112,29 +114,29 @@ func ValidateIP(ipStr string) string {
 	cleanIP := strings.TrimSpace(ipStr)
 	cleanIP = strings.TrimSuffix(cleanIP, "\n")
 	cleanIP = strings.TrimSuffix(cleanIP, "\r")
-	
+
 	// 使用正则表达式提取IP地址
 	ipv4Regex := regexp.MustCompile(`(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})`)
 	ipv6Regex := regexp.MustCompile(`([0-9a-fA-F:]+::[0-9a-fA-F:]*|[0-9a-fA-F:]*::[0-9a-fA-F:]+|[0-9a-fA-F:]+:[0-9a-fA-F:]+:[0-9a-fA-F:]+:[0-9a-fA-F:]+:[0-9a-fA-F:]+:[0-9a-fA-F:]+:[0-9a-fA-F:]+:[0-9a-fA-F:]+)`)
-	
+
 	// 先尝试IPv4
 	if match := ipv4Regex.FindString(cleanIP); match != "" {
 		if net.ParseIP(match) != nil {
 			return match
 		}
 	}
-	
+
 	// 再尝试IPv6
 	if match := ipv6Regex.FindString(cleanIP); match != "" {
 		if net.ParseIP(match) != nil {
 			return match
 		}
 	}
-	
+
 	// 直接验证清理后的字符串
 	if net.ParseIP(cleanIP) != nil {
 		return cleanIP
 	}
-	
+
 	return ""
-} 
+}

--- a/proxy/checker/net_quality_checker.go
+++ b/proxy/checker/net_quality_checker.go
@@ -4,20 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/bestruirui/bestsub/utils/log"
 	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
-
-	"github.com/bestruirui/bestsub/proxy/info"
-	"github.com/bestruirui/bestsub/utils/log"
 )
 
-// This file will house the core logic for network quality checks. 
+// This file will house the core logic for network quality checks.
 
 // Province represents a Chinese province for testing
 type Province struct {
@@ -52,29 +49,29 @@ type InternationalTestTarget struct {
 
 // NetQualityChecker provides network quality testing functionality
 type NetQualityChecker struct {
-	provinces             []Province
-	delayTargets          []DelayTestTarget
-	routeTargets          []RouteTestTarget
-	internationalTargets  []InternationalTestTarget
+	provinces            []Province
+	delayTargets         []DelayTestTarget
+	routeTargets         []RouteTestTarget
+	internationalTargets []InternationalTestTarget
 }
 
 // NewNetQualityChecker creates a new NetQualityChecker instance
 func NewNetQualityChecker() (*NetQualityChecker, error) {
 	checker := &NetQualityChecker{}
-	
+
 	// Ensure resource files are available
 	if err := EnsureResourceFiles(); err != nil {
 		return nil, fmt.Errorf("failed to ensure resource files: %w", err)
 	}
-	
+
 	// Load provinces data
 	if err := checker.loadProvinces(); err != nil {
 		return nil, fmt.Errorf("failed to load provinces: %w", err)
 	}
-	
+
 	// Initialize test targets
 	checker.initializeTestTargets()
-	
+
 	return checker, nil
 }
 
@@ -84,16 +81,16 @@ func (nqc *NetQualityChecker) loadProvinces() error {
 	if err != nil {
 		return fmt.Errorf("failed to get province.json path: %w", err)
 	}
-	
+
 	data, err := os.ReadFile(provincePath)
 	if err != nil {
 		return fmt.Errorf("failed to read province file: %w", err)
 	}
-	
+
 	if err := json.Unmarshal(data, &nqc.provinces); err != nil {
 		return fmt.Errorf("failed to unmarshal province data: %w", err)
 	}
-	
+
 	return nil
 }
 
@@ -101,7 +98,7 @@ func (nqc *NetQualityChecker) loadProvinces() error {
 func (nqc *NetQualityChecker) initializeTestTargets() {
 	// Initialize delay test targets for major provinces
 	majorProvinces := []string{"BJ", "SH", "GD"} // Beijing, Shanghai, Guangdong
-	
+
 	for _, provinceCode := range majorProvinces {
 		// Add targets for each ISP
 		nqc.delayTargets = append(nqc.delayTargets, []DelayTestTarget{
@@ -109,7 +106,7 @@ func (nqc *NetQualityChecker) initializeTestTargets() {
 			{Province: provinceCode, ISP: "CU", Host: fmt.Sprintf("%s-cu-v4.ip.zstaticcdn.com", strings.ToLower(provinceCode))},
 			{Province: provinceCode, ISP: "CM", Host: fmt.Sprintf("%s-cm-v4.ip.zstaticcdn.com", strings.ToLower(provinceCode))},
 		}...)
-		
+
 		// Add route test targets
 		nqc.routeTargets = append(nqc.routeTargets, []RouteTestTarget{
 			{Province: provinceCode, ISP: "CT", Host: fmt.Sprintf("%s-ct-v4.ip.zstaticcdn.com", strings.ToLower(provinceCode)), Protocol: "TCP"},
@@ -120,7 +117,7 @@ func (nqc *NetQualityChecker) initializeTestTargets() {
 			{Province: provinceCode, ISP: "CM", Host: fmt.Sprintf("%s-cm-v4.ip.zstaticcdn.com", strings.ToLower(provinceCode)), Protocol: "UDP"},
 		}...)
 	}
-	
+
 	// Initialize international test targets
 	nqc.internationalTargets = []InternationalTestTarget{
 		{Country: "US", City: "Los Angeles", Host: "lax.connectivitycheck.gstatic.com"},
@@ -140,9 +137,9 @@ func (c *Checker) CheckNetworkQuality() error {
 		log.Error("Failed to create NetQualityChecker: %v", err)
 		return err
 	}
-	
+
 	log.Info("Starting network quality check for proxy: %v", c.Proxy.Raw["name"])
-	
+
 	// Initialize NetInfo if not already done
 	if c.Proxy.Info.Net.Latency.ChinaTelecom == nil {
 		c.Proxy.Info.Net.Latency.ChinaTelecom = make(map[string]uint16)
@@ -151,27 +148,27 @@ func (c *Checker) CheckNetworkQuality() error {
 		c.Proxy.Info.Net.Latency.International = make(map[string]uint16)
 		c.Proxy.Info.Net.Route = make(map[string]string)
 	}
-	
+
 	// Check delays (with timeout for each test)
 	if err := nqc.checkDelays(c); err != nil {
 		log.Debug("Delays check completed with some errors: %v", err)
 	}
-	
+
 	// Check routes (with timeout for each test)
 	if err := nqc.checkRoutes(c); err != nil {
 		log.Debug("Routes check completed with some errors: %v", err)
 	}
-	
+
 	// Check international delays using iperf targets
 	if err := nqc.checkInternationalDelaysFromIperf(c); err != nil {
 		log.Debug("International iperf delays check completed with some errors: %v", err)
 	}
-	
+
 	// Check international delays using standard targets
 	if err := nqc.checkInternationalDelays(c); err != nil {
 		log.Debug("International delays check completed with some errors: %v", err)
 	}
-	
+
 	log.Info("Completed network quality check for proxy: %v", c.Proxy.Raw["name"])
 	return nil
 }
@@ -180,14 +177,14 @@ func (c *Checker) CheckNetworkQuality() error {
 func (nqc *NetQualityChecker) checkDelays(c *Checker) error {
 	ctx, cancel := context.WithTimeout(c.Proxy.Ctx, 60*time.Second)
 	defer cancel()
-	
+
 	for _, target := range nqc.delayTargets {
 		delay, err := nqc.measureTCPDelay(ctx, target.Host, c)
 		if err != nil {
 			log.Debug("Failed to measure delay to %s: %v", target.Host, err)
 			continue
 		}
-		
+
 		// Store delay based on ISP
 		key := fmt.Sprintf("%s-%s", target.Province, target.ISP)
 		switch target.ISP {
@@ -198,10 +195,10 @@ func (nqc *NetQualityChecker) checkDelays(c *Checker) error {
 		case "CM":
 			c.Proxy.Info.Net.Latency.ChinaMobile[key] = delay
 		}
-		
+
 		log.Debug("Delay to %s (%s): %d ms", target.Host, key, delay)
 	}
-	
+
 	return nil
 }
 
@@ -209,7 +206,7 @@ func (nqc *NetQualityChecker) checkDelays(c *Checker) error {
 func (nqc *NetQualityChecker) checkInternationalDelaysFromIperf(c *Checker) error {
 	// Load iperf targets from resource or use defaults
 	var iperfTargets []InternationalTestTarget
-	
+
 	// Try to load from iperf.json, fallback to defaults
 	targets, err := nqc.loadIperfTargetsAsInternational()
 	if err != nil {
@@ -218,10 +215,10 @@ func (nqc *NetQualityChecker) checkInternationalDelaysFromIperf(c *Checker) erro
 	} else {
 		iperfTargets = targets
 	}
-	
+
 	ctx, cancel := context.WithTimeout(c.Proxy.Ctx, 120*time.Second)
 	defer cancel()
-	
+
 	// Test each target with limited concurrency
 	for _, target := range iperfTargets {
 		delay, err := nqc.measureTCPDelay(ctx, target.Host, c)
@@ -229,16 +226,16 @@ func (nqc *NetQualityChecker) checkInternationalDelaysFromIperf(c *Checker) erro
 			log.Debug("Failed to measure international delay to %s: %v", target.Host, err)
 			continue
 		}
-		
+
 		key := fmt.Sprintf("%s-%s", target.Country, target.City)
 		c.Proxy.Info.Net.Latency.International[key] = delay
-		
+
 		log.Debug("International delay to %s (%s): %d ms", target.Host, key, delay)
-		
+
 		// Add small delay between tests to avoid overwhelming the proxy
 		time.Sleep(100 * time.Millisecond)
 	}
-	
+
 	return nil
 }
 
@@ -248,12 +245,12 @@ func (nqc *NetQualityChecker) loadIperfTargetsAsInternational() ([]International
 	if err != nil {
 		return nil, fmt.Errorf("failed to get iperf.json path: %w", err)
 	}
-	
+
 	data, err := os.ReadFile(iperfPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read iperf file: %w", err)
 	}
-	
+
 	// Define a local struct that matches the iperf.json format
 	type IperfTarget struct {
 		Code   int    `json:"code"`
@@ -263,12 +260,12 @@ func (nqc *NetQualityChecker) loadIperfTargetsAsInternational() ([]International
 		City   string `json:"city"`
 		CityZh string `json:"cityzh"`
 	}
-	
+
 	var iperfTargets []IperfTarget
 	if err := json.Unmarshal(data, &iperfTargets); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal iperf data: %w", err)
 	}
-	
+
 	// Convert to international targets
 	var targets []InternationalTestTarget
 	for _, iperf := range iperfTargets {
@@ -279,14 +276,14 @@ func (nqc *NetQualityChecker) loadIperfTargetsAsInternational() ([]International
 			Host:    iperf.Server,
 		})
 	}
-	
+
 	return targets, nil
 }
 
 // getCountryFromServer attempts to determine country from server hostname
 func (nqc *NetQualityChecker) getCountryFromServer(server string) string {
 	serverLower := strings.ToLower(server)
-	
+
 	if strings.Contains(serverLower, "he.net") || strings.Contains(serverLower, "fremont") {
 		return "US"
 	} else if strings.Contains(serverLower, "lon") || strings.Contains(serverLower, "london") {
@@ -308,7 +305,7 @@ func (nqc *NetQualityChecker) getCountryFromServer(server string) string {
 	} else if strings.Contains(serverLower, "singapore") {
 		return "SG"
 	}
-	
+
 	return "Unknown"
 }
 
@@ -334,13 +331,13 @@ func (nqc *NetQualityChecker) checkRoutes(c *Checker) error {
 			log.Debug("Failed to trace route to %s: %v", target.Host, err)
 			continue
 		}
-		
+
 		key := fmt.Sprintf("%s-%s-%s", target.Province, target.ISP, target.Protocol)
 		c.Proxy.Info.Net.Route[key] = route
-		
+
 		log.Debug("Route to %s (%s): %s", target.Host, key, route)
 	}
-	
+
 	return nil
 }
 
@@ -350,11 +347,11 @@ func (nqc *NetQualityChecker) traceRoute(host, protocol string) (string, error) 
 	if route, err := nqc.useNexttrace(host, protocol); err == nil {
 		return route, nil
 	}
-	
+
 	if route, err := nqc.useMTR(host, protocol); err == nil {
 		return route, nil
 	}
-	
+
 	// Fallback to basic route detection
 	return nqc.basicRouteDetection(host)
 }
@@ -363,25 +360,25 @@ func (nqc *NetQualityChecker) traceRoute(host, protocol string) (string, error) 
 func (nqc *NetQualityChecker) useNexttrace(host, protocol string) (string, error) {
 	var args []string
 	args = append(args, "-4", "--raw", "--psize", "1400", "-q", "8")
-	
+
 	switch strings.ToLower(protocol) {
 	case "tcp":
 		args = append(args, "--tcp", "-p", "80")
 	case "udp":
 		args = append(args, "--udp", "-p", "80")
 	}
-	
+
 	args = append(args, host)
-	
+
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	
+
 	cmd := exec.CommandContext(ctx, "nexttrace", args...)
 	output, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("nexttrace failed: %w", err)
 	}
-	
+
 	return nqc.parseNexttraceOutput(string(output))
 }
 
@@ -389,25 +386,25 @@ func (nqc *NetQualityChecker) useNexttrace(host, protocol string) (string, error
 func (nqc *NetQualityChecker) useMTR(host, protocol string) (string, error) {
 	var args []string
 	args = append(args, "-4", "-C", "-G", "1", "-s", "1400", "-c", "1", "-f", "100")
-	
+
 	switch strings.ToLower(protocol) {
 	case "tcp":
 		args = append(args, "--tcp", "-P", "80")
 	case "udp":
 		args = append(args, "--udp", "-P", "80")
 	}
-	
+
 	args = append(args, host)
-	
+
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	
+
 	cmd := exec.CommandContext(ctx, "mtr", args...)
 	output, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("mtr failed: %w", err)
 	}
-	
+
 	return nqc.parseMTROutput(string(output))
 }
 
@@ -418,13 +415,13 @@ func (nqc *NetQualityChecker) basicRouteDetection(host string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve %s: %w", host, err)
 	}
-	
+
 	if len(ips) == 0 {
 		return "", fmt.Errorf("no IPs found for %s", host)
 	}
-	
+
 	ip := ips[0].String()
-	
+
 	// Basic classification based on IP ranges (simplified)
 	if strings.HasPrefix(ip, "202.97") {
 		return "CN2GT", nil
@@ -437,7 +434,7 @@ func (nqc *NetQualityChecker) basicRouteDetection(host string) (string, error) {
 	} else if strings.Contains(host, "cm") || strings.Contains(host, "mobile") {
 		return "CMI", nil
 	}
-	
+
 	return "Unknown", nil
 }
 
@@ -445,7 +442,7 @@ func (nqc *NetQualityChecker) basicRouteDetection(host string) (string, error) {
 func (nqc *NetQualityChecker) parseNexttraceOutput(output string) (string, error) {
 	lines := strings.Split(output, "\n")
 	var asns []string
-	
+
 	for _, line := range lines {
 		// Look for AS numbers in the output
 		if strings.Contains(line, "AS") {
@@ -458,7 +455,7 @@ func (nqc *NetQualityChecker) parseNexttraceOutput(output string) (string, error
 			}
 		}
 	}
-	
+
 	return nqc.classifyRouteByASN(asns), nil
 }
 
@@ -466,7 +463,7 @@ func (nqc *NetQualityChecker) parseNexttraceOutput(output string) (string, error
 func (nqc *NetQualityChecker) parseMTROutput(output string) (string, error) {
 	lines := strings.Split(output, "\n")
 	var asns []string
-	
+
 	for _, line := range lines {
 		if strings.Contains(line, "AS") {
 			parts := strings.Split(line, ",")
@@ -478,7 +475,7 @@ func (nqc *NetQualityChecker) parseMTROutput(output string) (string, error) {
 			}
 		}
 	}
-	
+
 	return nqc.classifyRouteByASN(asns), nil
 }
 
@@ -488,7 +485,7 @@ func (nqc *NetQualityChecker) classifyRouteByASN(asns []string) string {
 	for _, asn := range asns {
 		asnSet[asn] = true
 	}
-	
+
 	// Check for specific ASN patterns
 	if asnSet["4809"] && asnSet["23764"] {
 		return "CTGGIA"
@@ -515,7 +512,7 @@ func (nqc *NetQualityChecker) classifyRouteByASN(asns []string) string {
 	} else if asnSet["7497"] {
 		return "CSTNET"
 	}
-	
+
 	return "Unknown"
 }
 
@@ -523,41 +520,41 @@ func (nqc *NetQualityChecker) classifyRouteByASN(asns []string) string {
 func (nqc *NetQualityChecker) checkInternationalDelays(c *Checker) error {
 	ctx, cancel := context.WithTimeout(c.Proxy.Ctx, 60*time.Second)
 	defer cancel()
-	
+
 	for _, target := range nqc.internationalTargets {
 		delay, err := nqc.measureTCPDelay(ctx, target.Host, c)
 		if err != nil {
 			log.Debug("Failed to measure international delay to %s: %v", target.Host, err)
 			continue
 		}
-		
+
 		key := fmt.Sprintf("%s-%s", target.Country, target.City)
 		c.Proxy.Info.Net.Latency.International[key] = delay
-		
+
 		log.Debug("International delay to %s (%s): %d ms", target.Host, key, delay)
 	}
-	
+
 	return nil
 }
 
 // measureTCPDelay measures TCP connection delay to a host using the proxy
 func (nqc *NetQualityChecker) measureTCPDelay(ctx context.Context, host string, c *Checker) (uint16, error) {
 	start := time.Now()
-	
+
 	// Create a connection through the proxy
 	conn, err := c.Proxy.Client.Transport.(*http.Transport).DialContext(ctx, "tcp", host+":80")
 	if err != nil {
 		return 0, fmt.Errorf("failed to connect to %s: %w", host, err)
 	}
 	defer conn.Close()
-	
+
 	delay := time.Since(start)
 	delayMs := uint16(delay.Milliseconds())
-	
+
 	// Cap delay at max uint16 value
 	if delay.Milliseconds() > 65535 {
 		delayMs = 65535
 	}
-	
+
 	return delayMs, nil
-} 
+}


### PR DESCRIPTION
## Summary
- drop unused imports and consts in IP usage checker
- clean banned checker imports
- use `FetchScamalyticsRiskData` in risk aggregator
- remove unused imports from network quality checker

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_68386b71df208331a2e8777e11babcb2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comprehensive IP information gathering for proxies, including public IP detection, risk scoring, usage data, and ban status checks.

- **Refactor**
  - Improved risk score aggregation logic for IP checks, streamlining concurrent data fetching from multiple services.

- **Style**
  - Cleaned up code formatting, reordered imports, and removed unused imports for improved readability and maintainability.

- **Chores**
  - Updated import statements and removed redundant constants to ensure consistency across files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->