### PR TITLE
Enable YAML provider filtering

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	Check           CheckConfig  `yaml:"check"`
 	PrintProgress   bool         `yaml:"print-progress"`
 	Save            SaveConfig   `yaml:"save"`
+	ProviderFile    string       `yaml:"provider-file"`
 	SubUrlsReTry    int          `yaml:"sub-urls-retry"`
 	SubUrls         []string     `yaml:"sub-urls"`
 	TypeInclude     []string     `yaml:"type-include"`

--- a/doc/README.md
+++ b/doc/README.md
@@ -37,6 +37,21 @@ docker run -itd \
 go run main.go -f /path/to/config.yaml -r /path/to/rename.yaml
 ```
 
+### Run Modes
+
+Use the `-mode` flag to control execution:
+
+- `test` – perform checks and output only `results.json`
+- `gen` – read an existing JSON specified by `-j` and generate providers
+- `both` – default, run checks and generate providers in one step
+
+Example:
+
+```bash
+go run main.go -mode test
+go run main.go -mode gen -j ./output/results.json
+```
+
 ## Custom Speed Test URL
 
 > (Optional) Since some nodes block common speed test URLs, you may need to create your own speed test URL

--- a/doc/README.md
+++ b/doc/README.md
@@ -12,7 +12,8 @@
 1. Select the appropriate file from the [releases](https://github.com/bestruirui/BestSub/releases) based on your system
 2. Download [config.example.yaml](https://raw.githubusercontent.com/bestruirui/BestSub/master/doc/config.example.yaml) and [rename.yaml](https://raw.githubusercontent.com/bestruirui/BestSub/master/doc/rename.yaml) to the `config` folder
 3. Refer to the [Configuration Documentation](./config.md) to modify the configuration file, then rename it to `config.yaml`
-4. Run the application
+4. (Optional) Create `providers.yaml` following the [Provider Filter Documentation](./provider_config.md)
+5. Run the application
 
 ## Docker
 

--- a/doc/README_zh.md
+++ b/doc/README_zh.md
@@ -36,6 +36,21 @@ docker run -itd \
 go run main.go -f /path/to/config.yaml -r /path/to/rename.yaml
 ```
 
+### 运行模式
+
+通过 `-mode` 参数控制程序行为：
+
+- `test` 仅执行检测并输出 `results.json`
+- `gen` 读取 `-j` 指定的 JSON 生成 provider 文件
+- `both` 默认模式，检测完成后同时生成 provider
+
+示例：
+
+```bash
+go run main.go -mode test
+go run main.go -mode gen -j ./output/results.json
+```
+
 
 ### 自建测速地址
 

--- a/doc/README_zh.md
+++ b/doc/README_zh.md
@@ -11,7 +11,8 @@
 1. 根据自己系统选择 [release](https://github.com/bestruirui/BestSub/releases) 中的文件
 2. 下载[config.example.yaml](https://raw.githubusercontent.com/bestruirui/BestSub/master/doc/config.example.yaml) 和 [rename.yaml](https://raw.githubusercontent.com/bestruirui/BestSub/master/doc/rename.yaml) 文件 到 `config` 文件夹中
 3. 参考[配置文件说明](./config_zh.md) 修改配置文件后，重命名为 `config.yaml`
-4. 运行即可
+4. （可选）根据[Provider 配置说明](./provider_config_zh.md) 编写 `providers.yaml`
+5. 运行即可
 
 ### Docker
 

--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -88,3 +88,5 @@ proxy:
 sub-urls:
   - https://example.com/sub1
   - https://example.com/sub2
+# Provider filter file
+provider-file: providers.yaml

--- a/doc/provider_config.md
+++ b/doc/provider_config.md
@@ -1,0 +1,95 @@
+# Provider Filter Configuration
+
+This document explains how to group checked proxies into different providers using a YAML file. Each provider mirrors the nested fields in `proxy/info/info.go`.
+
+## Basic Structure
+
+```yaml
+providers:
+  ProviderName:
+    output: filename.yaml   # optional, defaults to <ProviderName>.yaml
+    filter:
+      ...
+```
+
+## Constraint Rules
+
+- **String fields** use regular expressions.
+- **Numeric fields** support `>=`, `<=`, `>`, `<`, an inclusive `[min,max]` range or a single value.
+- **Boolean fields** match `true` or `false`.
+- **Map or struct fields** continue with nested keys.
+
+A proxy matches a provider only when all specified constraints are satisfied.
+
+## Available Filter Fields
+
+The main keys correspond to fields of `ProxyInfo`:
+
+- `country` *(string)* – ISO country code.
+- `alive` *(bool)* – whether the node responded to the connectivity test.
+- `speed` *(int)* – download speed in KB/s.
+- `delay` *(int)* – TCP handshake delay in milliseconds.
+- `rate` *(float)* – subscription rate multiplier.
+- `risk` *(int)* – overall risk score.
+- `unlock` *(map)* – streaming unlock results. Keys include `google`, `chatgpt`, `netflix`, `disney`, `youtube`, `cloudflare`, `tiktok`, `spotify`, `amazon`.
+- `ip` *(map)* – IP quality information:
+  - `ipUsage` – integer codes (0=home, 1=business, 2=hosting).
+  - `ipRisk` – integer scores (0=very low, 1=low, 2=medium, 3=high, 4=very high).
+  - `ipRiskFactor` – nested booleans such as `proxy`, `vpn`, `hosting`, `spam`.
+  - `ipBanned` – counts of `normal`, `tagged` and `banned` appearances.
+- `net` *(map)* – network information:
+  - `latency` – latency results with categories `ChinaTelecom`, `ChinaUnicom`, `ChinaMobile`, `International`. Each contains city names and delay in ms.
+  - `route` – return-route information, mapping route name to ASN string.
+
+Any field in `ProxyInfo` may be referenced in the filter using this nested style.
+
+## Example
+
+```yaml
+providers:
+  USFastClean:
+    output: us_fast.yaml
+    filter:
+      country: "^US$"
+      alive: true
+      speed: ">=10240"
+      delay: "<=50"
+      rate: "[0,1.5]"
+      unlock:
+        netflix: true
+        disney: true
+        youtube: true
+        chatgpt: true
+      ip:
+        ipUsage:
+          ipInfo: "[0,1]"
+        ipRisk:
+          ipqs: "<=1"
+          dbip: "<=2"
+        ipRiskFactor:
+          ip2Location:
+            hosting: false
+        ipBanned:
+          banned: 0
+      net:
+        latency:
+          International:
+            Tokyo: "<=70"
+          ChinaTelecom:
+            Shanghai: "<=150"
+        route:
+          Beijing-ChinaUnicom-TCP: "AS4837"
+  CNQuality:
+    filter:
+      country: "^CN$"
+      speed: ">2048"
+      unlock:
+        tiktok: true
+      ip:
+        ipBanned:
+          banned: 0
+        ipRisk:
+          ipqs: "<=2"
+```
+
+Set the path to this file with `provider-file` in `config.yaml`. After checks complete, matching proxies are written to the specified provider files and the full results are saved in `results.json`.

--- a/doc/provider_config.md
+++ b/doc/provider_config.md
@@ -80,6 +80,7 @@ providers:
         route:
           Beijing-ChinaUnicom-TCP: "AS4837"
   CNQuality:
+    output: cn_quality.yaml
     filter:
       country: "^CN$"
       speed: ">2048"

--- a/doc/provider_config_zh.md
+++ b/doc/provider_config_zh.md
@@ -1,0 +1,95 @@
+# Provider 配置说明
+
+本文档介绍如何通过 YAML 配置文件按检测结果对节点进行分组。每个 provider 的字段与 `proxy/info/info.go` 中的 `ProxyInfo` 结构保持一致。
+
+## 基本结构
+
+```yaml
+providers:
+  Provider名称:
+    output: 文件名.yaml   # 可选，默认为 Provider 名称 + .yaml
+    filter:
+      ...
+```
+
+## 编写规则
+
+- **字符串**：使用正则表达式匹配。
+- **数字**：支持 `>=`、`<=`、`>`、`<`、`[min,max]` 或单个数字。
+- **布尔值**：直接写 `true` 或 `false`。
+- **map/结构体**：在子项中继续编写约束。
+
+只有所有条件同时满足时，节点才会被划入对应的 provider。
+
+## 可用的过滤字段
+
+主要键与 `ProxyInfo` 中的字段对应：
+
+- `country` *(string)*：国家代码。
+- `alive` *(bool)*：节点是否在存活检测中成功连接。
+- `speed` *(int)*：下载速度，单位 KB/s。
+- `delay` *(int)*：TCP 握手延迟，单位毫秒。
+- `rate` *(float)*：订阅倍率。
+- `risk` *(int)*：综合风险分数。
+- `unlock` *(map)*：流媒体解锁情况，可用键有 `google`、`chatgpt`、`netflix`、`disney`、`youtube`、`cloudflare`、`tiktok`、`spotify`、`amazon`。
+- `ip` *(map)*：IP 纯净度相关信息：
+  - `ipUsage`：整数类型 (0=住宅，1=商业，2=托管)。
+  - `ipRisk`：整数评分 (0=极低，1=低，2=中，3=高，4=极高)。
+  - `ipRiskFactor`：布尔值字段，如 `proxy`、`vpn`、`hosting`、`spam` 等。
+  - `ipBanned`：`normal`、`tagged`、`banned` 的出现次数。
+- `net` *(map)*：网络质量相关信息：
+  - `latency`：延迟结果，包含 `ChinaTelecom`、`ChinaUnicom`、`ChinaMobile`、`International` 等分类，每个分类下为城市名到毫秒值的映射。
+  - `route`：回程路由信息，键为线路名称，值为 AS 号。
+
+只要在 `ProxyInfo` 中存在的字段，都可以用相同的嵌套写法在过滤器中引用。
+
+## 示例
+
+```yaml
+providers:
+  USFastClean:
+    output: us_fast.yaml
+    filter:
+      country: "^US$"
+      alive: true
+      speed: ">=10240"
+      delay: "<=50"
+      rate: "[0,1.5]"
+      unlock:
+        netflix: true
+        disney: true
+        youtube: true
+        chatgpt: true
+      ip:
+        ipUsage:
+          ipInfo: "[0,1]"
+        ipRisk:
+          ipqs: "<=1"
+          dbip: "<=2"
+        ipRiskFactor:
+          ip2Location:
+            hosting: false
+        ipBanned:
+          banned: 0
+      net:
+        latency:
+          International:
+            Tokyo: "<=70"
+          ChinaTelecom:
+            Shanghai: "<=150"
+        route:
+          Beijing-ChinaUnicom-TCP: "AS4837"
+  CNQuality:
+    filter:
+      country: "^CN$"
+      speed: ">2048"
+      unlock:
+        tiktok: true
+      ip:
+        ipBanned:
+          banned: 0
+        ipRisk:
+          ipqs: "<=2"
+```
+
+在 `config.yaml` 中通过 `provider-file` 选项指定此文件路径。程序运行结束后，会按配置生成各个 provider 文件，完整的检测结果存储在 `results.json` 中。

--- a/doc/provider_config_zh.md
+++ b/doc/provider_config_zh.md
@@ -80,6 +80,7 @@ providers:
         route:
           Beijing-ChinaUnicom-TCP: "AS4837"
   CNQuality:
+    output: cn_quality.yaml
     filter:
       country: "^CN$"
       speed: ">2048"

--- a/doc/providers.example.yaml
+++ b/doc/providers.example.yaml
@@ -32,6 +32,7 @@ providers:
         route:
           Beijing-ChinaUnicom-TCP: "AS4837"
   CNQuality:
+    output: "cn_quality.yaml"
     filter:
       country: "^CN$"
       speed: ">2048"

--- a/doc/providers.example.yaml
+++ b/doc/providers.example.yaml
@@ -1,0 +1,44 @@
+providers:
+  USFastClean:
+    output: "us_fast.yaml"
+    filter:
+      country: "^US$"
+      alive: true
+      speed: ">=10240"
+      delay: "<=50"
+      rate: "[0,1.5]"
+      unlock:
+        disney: true
+        netflix: true
+        youtube: true
+        chatgpt: true
+      ip:
+        ipUsage:
+          ipInfo: "[0,1]"
+        ipRisk:
+          ipqs: "<=1"
+          dbip: "<=2"
+        ipRiskFactor:
+          ip2Location:
+            hosting: false
+        ipBanned:
+          banned: 0
+      net:
+        latency:
+          International:
+            Tokyo: "<=70"
+          ChinaTelecom:
+            Shanghai: "<=150"
+        route:
+          Beijing-ChinaUnicom-TCP: "AS4837"
+  CNQuality:
+    filter:
+      country: "^CN$"
+      speed: ">2048"
+      unlock:
+        tiktok: true
+      ip:
+        ipBanned:
+          banned: 0
+        ipRisk:
+          ipqs: "<=2"

--- a/main.go
+++ b/main.go
@@ -26,6 +26,8 @@ type App struct {
 	renamePath   string
 	configPath   string
 	providerPath string
+	resultsPath  string
+	mode         string
 	interval     int
 	watcher      *fsnotify.Watcher
 	reloadTimer  *time.Timer
@@ -35,12 +37,16 @@ func NewApp() *App {
 	configPath := flag.String("f", "", "config file path")
 	renamePath := flag.String("r", "", "rename file path")
 	providerPath := flag.String("p", "", "provider file path")
+	resultsPath := flag.String("j", "", "results json path")
+	mode := flag.String("mode", "both", "run mode: test|gen|both")
 	flag.Parse()
 
 	return &App{
 		configPath:   *configPath,
 		renamePath:   *renamePath,
 		providerPath: *providerPath,
+		resultsPath:  *resultsPath,
+		mode:         *mode,
 	}
 }
 
@@ -125,6 +131,11 @@ func (app *App) loadConfig() error {
 	}
 	config.GlobalConfig.ProviderFile = app.providerPath
 
+	if app.resultsPath == "" {
+		execPath := utils.GetExecutablePath()
+		app.resultsPath = filepath.Join(execPath, "output", "results.json")
+	}
+
 	info.CountryCodeRegexInit(app.renamePath)
 
 	return nil
@@ -188,12 +199,28 @@ func (app *App) Run() {
 		}
 	}()
 
-	for {
-		maintask()
-		utils.UpdateSubs()
-		nextCheck := time.Now().Add(time.Duration(app.interval) * time.Minute)
-		log.Info("next check time: %v", nextCheck.Format("2006-01-02 15:04:05"))
-		time.Sleep(time.Duration(app.interval) * time.Minute)
+	switch app.mode {
+	case "test":
+		results := maintask()
+		saver.SaveResults(&results)
+		return
+	case "gen":
+		results, err := saver.LoadResults(app.resultsPath)
+		if err != nil {
+			log.Error("load results failed: %v", err)
+			return
+		}
+		saver.GenerateProviders(&results)
+		return
+	default:
+		for {
+			results := maintask()
+			saver.SaveConfig(&results)
+			utils.UpdateSubs()
+			nextCheck := time.Now().Add(time.Duration(app.interval) * time.Minute)
+			log.Info("next check time: %v", nextCheck.Format("2006-01-02 15:04:05"))
+			time.Sleep(time.Duration(app.interval) * time.Minute)
+		}
 	}
 }
 
@@ -208,7 +235,7 @@ func main() {
 
 	app.Run()
 }
-func maintask() {
+func maintask() []info.Proxy {
 	proxies := make([]info.Proxy, 0)
 
 	proxy.GetProxies(&proxies)
@@ -300,12 +327,9 @@ func maintask() {
 		log.Info("end speed test")
 	}
 
-	saver.SaveConfig(&proxies)
-
-	proxies = nil
-
 	pool.Release()
 
+	return proxies
 }
 
 func proxyCheckTask(proxy *info.Proxy) {

--- a/main.go
+++ b/main.go
@@ -97,9 +97,6 @@ func (app *App) initConfigPath() error {
 	if app.renamePath == "" {
 		app.renamePath = filepath.Join(configDir, "rename.yaml")
 	}
-	if app.providerPath == "" {
-		app.providerPath = filepath.Join(configDir, "providers.yaml")
-	}
 	return nil
 }
 
@@ -119,11 +116,14 @@ func (app *App) loadConfig() error {
 		return fmt.Errorf("parse config file failed: %w", err)
 	}
 
-	if config.GlobalConfig.ProviderFile == "" {
-		config.GlobalConfig.ProviderFile = app.providerPath
-	} else {
+	if app.providerPath == "" {
 		app.providerPath = config.GlobalConfig.ProviderFile
 	}
+	if app.providerPath == "" {
+		execPath := utils.GetExecutablePath()
+		app.providerPath = filepath.Join(execPath, "config", "providers.yaml")
+	}
+	config.GlobalConfig.ProviderFile = app.providerPath
 
 	info.CountryCodeRegexInit(app.renamePath)
 

--- a/main.go
+++ b/main.go
@@ -23,21 +23,24 @@ import (
 )
 
 type App struct {
-	renamePath  string
-	configPath  string
-	interval    int
-	watcher     *fsnotify.Watcher
-	reloadTimer *time.Timer
+	renamePath   string
+	configPath   string
+	providerPath string
+	interval     int
+	watcher      *fsnotify.Watcher
+	reloadTimer  *time.Timer
 }
 
 func NewApp() *App {
 	configPath := flag.String("f", "", "config file path")
 	renamePath := flag.String("r", "", "rename file path")
+	providerPath := flag.String("p", "", "provider file path")
 	flag.Parse()
 
 	return &App{
-		configPath: *configPath,
-		renamePath: *renamePath,
+		configPath:   *configPath,
+		renamePath:   *renamePath,
+		providerPath: *providerPath,
 	}
 }
 
@@ -94,6 +97,9 @@ func (app *App) initConfigPath() error {
 	if app.renamePath == "" {
 		app.renamePath = filepath.Join(configDir, "rename.yaml")
 	}
+	if app.providerPath == "" {
+		app.providerPath = filepath.Join(configDir, "providers.yaml")
+	}
 	return nil
 }
 
@@ -111,6 +117,12 @@ func (app *App) loadConfig() error {
 
 	if err := yaml.Unmarshal(yamlFile, &config.GlobalConfig); err != nil {
 		return fmt.Errorf("parse config file failed: %w", err)
+	}
+
+	if config.GlobalConfig.ProviderFile == "" {
+		config.GlobalConfig.ProviderFile = app.providerPath
+	} else {
+		app.providerPath = config.GlobalConfig.ProviderFile
 	}
 
 	info.CountryCodeRegexInit(app.renamePath)

--- a/providerconfig/providerconfig.go
+++ b/providerconfig/providerconfig.go
@@ -1,0 +1,262 @@
+package providerconfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/bestruirui/bestsub/proxy/info"
+	"gopkg.in/yaml.v3"
+)
+
+type providerFile struct {
+	Providers map[string]Provider `yaml:"providers"`
+}
+
+type Provider struct {
+	Output string                 `yaml:"output"`
+	Filter map[string]interface{} `yaml:"filter"`
+}
+
+func Load(path string) ([]Provider, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var pf providerFile
+	if err := yaml.Unmarshal(data, &pf); err != nil {
+		return nil, err
+	}
+	providers := make([]Provider, 0, len(pf.Providers))
+	for name, p := range pf.Providers {
+		if p.Output == "" {
+			p.Output = fmt.Sprintf("%s.yaml", name)
+		}
+		providers = append(providers, p)
+	}
+	return providers, nil
+}
+
+func Match(filter map[string]interface{}, infoData info.ProxyInfo) bool {
+	return matchMap(filter, reflect.ValueOf(infoData))
+}
+
+func matchMap(filter map[string]interface{}, val reflect.Value) bool {
+	for k, cond := range filter {
+		f := findFieldOrMap(val, k)
+		if !f.IsValid() {
+			return false
+		}
+		if !matchValue(cond, f) {
+			return false
+		}
+	}
+	return true
+}
+
+func findFieldOrMap(val reflect.Value, key string) reflect.Value {
+	if val.Kind() == reflect.Pointer {
+		if val.IsNil() {
+			return reflect.Value{}
+		}
+		val = val.Elem()
+	}
+	switch val.Kind() {
+	case reflect.Struct:
+		typ := val.Type()
+		for i := 0; i < typ.NumField(); i++ {
+			if strings.EqualFold(typ.Field(i).Name, key) {
+				return val.Field(i)
+			}
+		}
+	case reflect.Map:
+		mv := val.MapIndex(reflect.ValueOf(key))
+		if mv.IsValid() {
+			return mv
+		}
+		for _, mk := range val.MapKeys() {
+			if strings.EqualFold(mk.String(), key) {
+				return val.MapIndex(mk)
+			}
+		}
+	}
+	return reflect.Value{}
+}
+
+func matchValue(cond interface{}, val reflect.Value) bool {
+	if val.Kind() == reflect.Pointer || val.Kind() == reflect.Interface {
+		if val.IsNil() {
+			return false
+		}
+		val = val.Elem()
+	}
+	switch val.Kind() {
+	case reflect.Bool:
+		b, ok := cond.(bool)
+		if !ok {
+			return false
+		}
+		return val.Bool() == b
+	case reflect.String:
+		s, ok := cond.(string)
+		if !ok {
+			s = fmt.Sprintf("%v", cond)
+		}
+		re, err := regexp.Compile(s)
+		if err != nil {
+			return false
+		}
+		return re.MatchString(val.String())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return matchNumber(cond, float64(val.Int()))
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return matchNumber(cond, float64(val.Uint()))
+	case reflect.Float32, reflect.Float64:
+		return matchNumber(cond, val.Float())
+	case reflect.Map, reflect.Struct:
+		m, ok := cond.(map[string]interface{})
+		if !ok {
+			return false
+		}
+		return matchMap(m, val)
+	default:
+		return false
+	}
+}
+
+func matchNumber(cond interface{}, val float64) bool {
+	switch c := cond.(type) {
+	case string:
+		s := strings.TrimSpace(c)
+		if strings.HasPrefix(s, ">=") {
+			t, err := strconv.ParseFloat(strings.TrimSpace(s[2:]), 64)
+			if err != nil {
+				return false
+			}
+			return val >= t
+		}
+		if strings.HasPrefix(s, "<=") {
+			t, err := strconv.ParseFloat(strings.TrimSpace(s[2:]), 64)
+			if err != nil {
+				return false
+			}
+			return val <= t
+		}
+		if strings.HasPrefix(s, ">") {
+			t, err := strconv.ParseFloat(strings.TrimSpace(s[1:]), 64)
+			if err != nil {
+				return false
+			}
+			return val > t
+		}
+		if strings.HasPrefix(s, "<") {
+			t, err := strconv.ParseFloat(strings.TrimSpace(s[1:]), 64)
+			if err != nil {
+				return false
+			}
+			return val < t
+		}
+		if strings.HasPrefix(s, "[") && strings.HasSuffix(s, "]") {
+			parts := strings.Split(strings.TrimSuffix(strings.TrimPrefix(s, "["), "]"), ",")
+			if len(parts) == 2 {
+				min, err1 := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
+				max, err2 := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+				if err1 != nil || err2 != nil {
+					return false
+				}
+				return val >= min && val <= max
+			}
+		}
+		t, err := strconv.ParseFloat(s, 64)
+		if err == nil {
+			return val == t
+		}
+		return false
+	case int, int8, int16, int32, int64:
+		t := reflect.ValueOf(c).Int()
+		return val == float64(t)
+	case uint, uint8, uint16, uint32, uint64:
+		t := reflect.ValueOf(c).Uint()
+		return val == float64(t)
+	case float32, float64:
+		t := reflect.ValueOf(c).Float()
+		return val == t
+	default:
+		return false
+	}
+}
+
+func MarshalExample() ([]byte, error) {
+	example := providerFile{
+		Providers: map[string]Provider{
+			"USFastClean": {
+				Output: "us_fast.yaml",
+				Filter: map[string]interface{}{
+					"country": "^US$",
+					"alive":   true,
+					"speed":   ">=10240",
+					"delay":   "<=50",
+					"rate":    "[0,1.5]",
+					"unlock": map[string]interface{}{
+						"netflix": true,
+						"disney":  true,
+						"youtube": true,
+						"chatgpt": true,
+					},
+					"ip": map[string]interface{}{
+						"ipUsage": map[string]interface{}{
+							"ipInfo": "[0,1]",
+						},
+						"ipRisk": map[string]interface{}{
+							"ipqs": "<=1",
+							"dbip": "<=2",
+						},
+						"ipRiskFactor": map[string]interface{}{
+							"ip2Location": map[string]interface{}{
+								"hosting": false,
+							},
+						},
+						"ipBanned": map[string]interface{}{
+							"banned": 0,
+						},
+					},
+					"net": map[string]interface{}{
+						"latency": map[string]interface{}{
+							"International": map[string]interface{}{
+								"Tokyo": "<=70",
+							},
+							"ChinaTelecom": map[string]interface{}{
+								"Shanghai": "<=150",
+							},
+						},
+						"route": map[string]interface{}{
+							"Beijing-ChinaUnicom-TCP": "AS4837",
+						},
+					},
+				},
+			},
+			"CNQuality": {
+				Filter: map[string]interface{}{
+					"country": "^CN$",
+					"speed":   ">2048",
+					"unlock": map[string]interface{}{
+						"tiktok": true,
+					},
+					"ip": map[string]interface{}{
+						"ipBanned": map[string]interface{}{
+							"banned": 0,
+						},
+						"ipRisk": map[string]interface{}{
+							"ipqs": "<=2",
+						},
+					},
+				},
+			},
+		},
+	}
+	return json.MarshalIndent(example, "", "  ")
+}

--- a/proxy/saver/saver.go
+++ b/proxy/saver/saver.go
@@ -112,6 +112,37 @@ func SaveConfig(results *[]info.Proxy) {
 	}
 }
 
+// SaveResults writes only the results.json file without generating providers.
+func SaveResults(results *[]info.Proxy) {
+	saver := NewConfigSaver(results)
+	saver.saveResults()
+}
+
+// GenerateProviders categorizes proxies by provider rules and saves provider files
+// without modifying or saving the results JSON.
+func GenerateProviders(results *[]info.Proxy) {
+	saver := NewConfigSaver(results)
+	saver.categorizeProxies()
+	for _, category := range saver.categories {
+		if err := saver.saveCategory(category); err != nil {
+			log.Error("save %s category failed: %v", category.Name, err)
+		}
+	}
+}
+
+// LoadResults reads a results.json file into a slice of Proxy objects.
+func LoadResults(path string) ([]info.Proxy, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var results []info.Proxy
+	if err := json.Unmarshal(data, &results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (cs *ConfigSaver) Save() error {
 	cs.categorizeProxies()
 	cs.saveResults()

--- a/proxy/saver/saver.go
+++ b/proxy/saver/saver.go
@@ -1,9 +1,12 @@
 package saver
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/bestruirui/bestsub/config"
+	"github.com/bestruirui/bestsub/providerconfig"
 	"github.com/bestruirui/bestsub/proxy/info"
 	"github.com/bestruirui/bestsub/utils/log"
 	"gopkg.in/yaml.v3"
@@ -22,40 +25,70 @@ type ConfigSaver struct {
 }
 
 func NewConfigSaver(results *[]info.Proxy) *ConfigSaver {
-	return &ConfigSaver{
+	saver := &ConfigSaver{
 		results:     results,
 		saveMethods: chooseSaveMethods(),
-		categories: []ProxyCategory{
-			{
-				Name:    "all.yaml",
-				Proxies: make([]map[string]any, 0),
-				Filter:  func(result info.Proxy) bool { return result.Info.Alive },
+		categories:  make([]ProxyCategory, 0),
+	}
+
+	providers, err := providerconfig.Load(config.GlobalConfig.ProviderFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Info("provider file not found: %v", config.GlobalConfig.ProviderFile)
+		} else {
+			log.Error("load provider file failed: %v", err)
+		}
+	}
+
+	for _, p := range providers {
+		prov := p
+		saver.categories = append(saver.categories, ProxyCategory{
+			Name:    prov.Output,
+			Proxies: make([]map[string]any, 0),
+			Filter: func(result info.Proxy) bool {
+				return providerconfig.Match(prov.Filter, result.Info)
 			},
-			{
-				Name:    "speed.yaml",
-				Proxies: make([]map[string]any, 0),
-				Filter:  func(result info.Proxy) bool { return result.Info.Speed > config.GlobalConfig.Check.MinSpeed },
-			},
-			{
-				Name:    "openai.yaml",
-				Proxies: make([]map[string]any, 0),
-				Filter:  func(result info.Proxy) bool { return result.Info.Unlock.Chatgpt },
-			},
-			{
-				Name:    "youtube.yaml",
-				Proxies: make([]map[string]any, 0),
-				Filter:  func(result info.Proxy) bool { return result.Info.Unlock.Youtube },
-			},
-			{
-				Name:    "netflix.yaml",
-				Proxies: make([]map[string]any, 0),
-				Filter:  func(result info.Proxy) bool { return result.Info.Unlock.Netflix },
-			},
-			{
-				Name:    "disney.yaml",
-				Proxies: make([]map[string]any, 0),
-				Filter:  func(result info.Proxy) bool { return result.Info.Unlock.Disney },
-			},
+		})
+	}
+
+	if len(saver.categories) == 0 {
+		saver.categories = defaultCategories()
+	}
+
+	return saver
+}
+
+func defaultCategories() []ProxyCategory {
+	return []ProxyCategory{
+		{
+			Name:    "all.yaml",
+			Proxies: make([]map[string]any, 0),
+			Filter:  func(result info.Proxy) bool { return result.Info.Alive },
+		},
+		{
+			Name:    "speed.yaml",
+			Proxies: make([]map[string]any, 0),
+			Filter:  func(result info.Proxy) bool { return result.Info.Speed > config.GlobalConfig.Check.MinSpeed },
+		},
+		{
+			Name:    "openai.yaml",
+			Proxies: make([]map[string]any, 0),
+			Filter:  func(result info.Proxy) bool { return result.Info.Unlock.Chatgpt },
+		},
+		{
+			Name:    "youtube.yaml",
+			Proxies: make([]map[string]any, 0),
+			Filter:  func(result info.Proxy) bool { return result.Info.Unlock.Youtube },
+		},
+		{
+			Name:    "netflix.yaml",
+			Proxies: make([]map[string]any, 0),
+			Filter:  func(result info.Proxy) bool { return result.Info.Unlock.Netflix },
+		},
+		{
+			Name:    "disney.yaml",
+			Proxies: make([]map[string]any, 0),
+			Filter:  func(result info.Proxy) bool { return result.Info.Unlock.Disney },
 		},
 	}
 }
@@ -81,6 +114,7 @@ func SaveConfig(results *[]info.Proxy) {
 
 func (cs *ConfigSaver) Save() error {
 	cs.categorizeProxies()
+	cs.saveResults()
 
 	for _, category := range cs.categories {
 		if err := cs.saveCategory(category); err != nil {
@@ -90,6 +124,19 @@ func (cs *ConfigSaver) Save() error {
 	}
 
 	return nil
+}
+
+func (cs *ConfigSaver) saveResults() {
+	jsonData, err := json.MarshalIndent(cs.results, "", "  ")
+	if err != nil {
+		log.Error("serialize results failed: %v", err)
+		return
+	}
+	for _, saveMethod := range cs.saveMethods {
+		if err := saveMethod(jsonData, "results.json"); err != nil {
+			log.Error("save results failed with one method: %v", err)
+		}
+	}
 }
 
 func (cs *ConfigSaver) categorizeProxies() {


### PR DESCRIPTION
## Summary
- allow specifying a provider constraint file via `provider-file` in config
- add providerconfig package for loading provider constraints and matching results
- hook provider config into ConfigSaver and output `results.json`
- provide example `providers.example.yaml` with complex constraints
- document provider configuration in English and Chinese
- **expand provider filter docs with details on available fields**
- fix numeric comparison parsing and handle missing provider files gracefully

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_b_6846089ba9508330967efe9c21280643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for loading and applying advanced proxy provider filters from an external YAML configuration file.
  - Introduced a new command-line option and configuration field to specify the provider filter file.
  - Provider-specific proxy groups can now be defined using flexible filtering criteria, with results saved to individual files.
  - Full proxy check results are now saved in a comprehensive JSON file.

- **Documentation**
  - Updated usage instructions and configuration examples to reflect provider filter support.
  - Added detailed documentation (in both English and Chinese) explaining how to configure provider filters.
  - Provided example YAML files demonstrating provider filter configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->